### PR TITLE
refactor: remove deprecated method and clean up related tests

### DIFF
--- a/3rdparty/aidaemon/org.deepin.ai.daemon.apisession.texttospeech.xml
+++ b/3rdparty/aidaemon/org.deepin.ai.daemon.apisession.texttospeech.xml
@@ -1,13 +1,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
   <interface name="org.deepin.ai.daemon.Session.TextToSpeech">
-    <!-- Text-to-speech synthesis -->
-    <method name="synthesizeText">
-      <arg name="text" type="s" direction="in"/>
-      <arg name="params" type="s" direction="in"/>
-      <arg type="s" direction="out"/>
-    </method>
-    
     <!-- Stream-based synthesis -->
     <method name="startStreamSynthesis">
       <arg name="text" type="s" direction="in"/>

--- a/examples/speech/texttospeech_test.cpp
+++ b/examples/speech/texttospeech_test.cpp
@@ -54,42 +54,6 @@ TextToSpeechTest::~TextToSpeechTest()
     qDebug() << "TextToSpeechTest destructor";
 }
 
-void TextToSpeechTest::testSynthesis()
-{
-    qDebug() << "Testing text synthesis...";
-    
-    // Get supported voices
-    QStringList voices = tts->getSupportedVoices();
-    qDebug() << "Supported voices:" << voices;
-    
-    // Test text synthesis
-    QString testText = "这是一个语音合成测试，Hello World!";
-    QVariantHash params;
-    params["voice"] = "x4_yezi";
-    params["speed"] = 50;
-    params["volume"] = 50;
-    params["pitch"] = 50;
-    
-    qDebug() << "Synthesizing text:" << testText;
-    QByteArray audioData = tts->synthesizeText(testText, params);
-    
-    if (!audioData.isEmpty()) {
-        qDebug() << "Synthesis successful, audio data size:" << audioData.size();
-        
-        // Save audio data to file
-        QFile file("synthesized_audio.pcm");
-        if (file.open(QIODevice::WriteOnly)) {
-            file.write(audioData);
-            file.close();
-            qDebug() << "Audio data saved to synthesized_audio.pcm";
-        } else {
-            qDebug() << "Failed to save audio data to file";
-        }
-    } else {
-        qDebug() << "Synthesis failed:" << tts->lastError().getErrorMessage();
-    }
-}
-
 void TextToSpeechTest::testStreamSynthesis()
 {
     qDebug() << "Testing stream synthesis...";
@@ -179,10 +143,6 @@ int main(int argc, char *argv[])
     qDebug() << "About to create TextToSpeechTest instance";
     TextToSpeechTest test;
     qDebug() << "TextToSpeechTest instance created";
-    
-    // Test basic synthesis
-    qDebug() << "Testing basic synthesis mode...";
-    test.testSynthesis();
     
     // Wait a bit before testing stream synthesis
     QTimer::singleShot(2000, [&test]() {

--- a/examples/vision/image_recognition_demo.cpp
+++ b/examples/vision/image_recognition_demo.cpp
@@ -11,6 +11,7 @@
  */
 #include <DAIError>
 #include <DImageRecognition>
+#include <DError>
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -65,7 +66,7 @@ private:
         QStringList formats = imageRecognition->getSupportedImageFormats();
         auto error = imageRecognition->lastError();
         
-        if (error.getErrorCode() != -1) {
+        if (error.getErrorCode() != NoError) {
             qWarning() << "✗ 获取支持格式失败:" << error.getErrorCode() << error.getErrorMessage();
         } else {
             qInfo() << "✓ 支持的图像格式:" << formats;
@@ -75,7 +76,7 @@ private:
         int maxSize = imageRecognition->getMaxImageSize();
         error = imageRecognition->lastError();
         
-        if (error.getErrorCode() != -1) {
+        if (error.getErrorCode() != NoError) {
             qWarning() << "✗ 获取最大图像尺寸失败:" << error.getErrorCode() << error.getErrorMessage();
         } else {
             qInfo() << "✓ 最大图像尺寸:" << maxSize << "bytes (" << (maxSize / 1024 / 1024) << "MB)";
@@ -99,7 +100,7 @@ private:
         QString result = imageRecognition->recognizeImageUrl(imageUrl, prompt);
         auto error = imageRecognition->lastError();
         
-        if (error.getErrorCode() != -1) {
+        if (error.getErrorCode() != NoError) {
             qWarning() << "✗ 图像识别失败:" << error.getErrorCode() << error.getErrorMessage();
             
             // Print detailed error information

--- a/include/dtkai/dtexttospeech.h
+++ b/include/dtkai/dtexttospeech.h
@@ -25,9 +25,6 @@ public:
     explicit DTextToSpeech(QObject *parent = nullptr);
     ~DTextToSpeech();
     
-    // Text synthesis
-    QByteArray synthesizeText(const QString &text, const QVariantHash &params = {});
-    
     // Stream-based synthesis
     bool startStreamSynthesis(const QString &text, const QVariantHash &params = {});
     QByteArray endStreamSynthesis();

--- a/src/nlp/dchatcompletions.cpp
+++ b/src/nlp/dchatcompletions.cpp
@@ -17,6 +17,7 @@ DAI_USE_NAMESPACE
 
 DChatCompletionsPrivate::DChatCompletionsPrivate(DChatCompletions *parent)
     : QObject()
+    , error(NoError, "")
     , q(parent)
 {
 
@@ -145,7 +146,7 @@ QString DChatCompletions::chat(const QString &prompt, const QList<ChatHistory> &
             d->error = DError(var.value("error").toInt(), var.value("errorMessage").toString());
         } else {
             ret = var.value("content").toString();
-            d->error = DError(0, "");
+            d->error = DError(NoError, "");
         }
     }
 

--- a/src/nlp/dfunctioncalling.cpp
+++ b/src/nlp/dfunctioncalling.cpp
@@ -15,7 +15,9 @@ DAI_USE_NAMESPACE
 #define CHAT_TIMEOUT 30 * 1000  
 #define REQ_TIMEOUT  10 * 1000
 
-DFunctionCallingPrivate::DFunctionCallingPrivate(DFunctionCalling *parent) : q(parent)
+DFunctionCallingPrivate::DFunctionCallingPrivate(DFunctionCalling *parent)
+    : error(NoError, "")
+    , q(parent)
 {
 
 }
@@ -103,7 +105,7 @@ QString DFunctionCalling::parse(const QString &prompt, const QString &functions,
             auto jObj = QJsonObject::fromVariantHash(var.value("function").value<QVariantHash>());
             QJsonDocument doc(jObj);
             ret = QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
-            d->error = DError(0, "");
+            d->error = DError(NoError, "");
         }
     }
 

--- a/src/speech/dspeechtotext_p.h
+++ b/src/speech/dspeechtotext_p.h
@@ -8,6 +8,8 @@
 #include "dspeechtotext.h"
 #include "aidaemon_apisession_speechtotext.h"
 
+#include <QJsonDocument>
+
 DAI_BEGIN_NAMESPACE
 
 class DSpeechToTextPrivate : public QObject
@@ -18,6 +20,9 @@ public:
     ~DSpeechToTextPrivate();
     bool ensureServer();
     static QString packageParams(const QVariantHash &params);
+    
+    // JSON response parsing function
+    static QString parseRecognitionResult(const QString &jsonResult, DTK_CORE_NAMESPACE::DError *error = nullptr);
     
 public Q_SLOTS:
     void onRecognitionResult(const QString &streamSessionId, const QString &text);

--- a/src/vision/dimagerecognition.cpp
+++ b/src/vision/dimagerecognition.cpp
@@ -20,6 +20,7 @@ static constexpr int REQ_TIMEOUT = 30000;
 
 DImageRecognitionPrivate::DImageRecognitionPrivate(DImageRecognition *parent)
     : QObject(parent)
+    , error(NoError, "")
     , q(parent)
 {
 }
@@ -103,7 +104,7 @@ QString DImageRecognition::recognizeImage(const QString &imagePath, const QStrin
     
     QMutexLocker lk(&d->mtx);
     d->running = true;
-    d->error = DError();
+    d->error = DError(NoError, "");
     
     QString ret = d->imageIfs->recognizeImage(imagePath, prompt, d->packageParams(params));
     
@@ -143,7 +144,7 @@ QString DImageRecognition::recognizeImageData(const QByteArray &imageData, const
     
     QMutexLocker lk(&d->mtx);
     d->running = true;
-    d->error = DError();
+    d->error = DError(NoError, "");
     
     QString ret = d->imageIfs->recognizeImageData(imageData, prompt, d->packageParams(params));
     
@@ -183,7 +184,7 @@ QString DImageRecognition::recognizeImageUrl(const QString &imageUrl, const QStr
     
     QMutexLocker lk(&d->mtx);
     d->running = true;
-    d->error = DError();
+    d->error = DError(NoError, "");
     
     QString ret = d->imageIfs->recognizeImageUrl(imageUrl, prompt, d->packageParams(params));
     

--- a/src/vision/docrrecognition.cpp
+++ b/src/vision/docrrecognition.cpp
@@ -20,6 +20,7 @@ static constexpr int REQ_TIMEOUT = 30000;
 DOCRRecognitionPrivate::DOCRRecognitionPrivate(DOCRRecognition *parent)
     : QObject(parent)
     , q(parent)
+    , error(NoError, "")
 {
 }
 
@@ -90,7 +91,7 @@ QString DOCRRecognition::recognizeFile(const QString &imageFile, const QVariantH
     
     QMutexLocker lk(&d->mtx);
     d->running = true;
-    d->error = DError();
+    d->error = DError(NoError, "");
     
     QString ret = d->ocrIfs->recognizeFile(imageFile, d->packageParams(params));
     
@@ -130,7 +131,7 @@ QString DOCRRecognition::recognizeImage(const QByteArray &imageData, const QVari
     
     QMutexLocker lk(&d->mtx);
     d->running = true;
-    d->error = DError();
+    d->error = DError(NoError, "");
     
     QString ret = d->ocrIfs->recognizeImage(imageData, d->packageParams(params));
     
@@ -175,7 +176,7 @@ QString DOCRRecognition::recognizeRegionFromString(const QString &imageFile, con
     
     QMutexLocker lk(&d->mtx);
     d->running = true;
-    d->error = DError();
+    d->error = DError(NoError, "");
     
     QString ret = d->ocrIfs->recognizeRegion(imageFile, region, d->packageParams(params));
     

--- a/tests/common/test_base.h
+++ b/tests/common/test_base.h
@@ -66,8 +66,6 @@ private:
             char **argv = nullptr;
             app = new QCoreApplication(argc, argv);
         }
-        
-        qDebug() << "Test environment setup completed";
     }
     
     void cleanupTestEnvironment()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -23,7 +23,7 @@ file(GLOB_RECURSE TEST_FILES
 )
 
 # Create test executable
-add_executable(${BIN_NAME} ${TEST_FILES})
+add_executable(${BIN_NAME} ${TEST_FILES} test_resources.qrc)
 
 # Include directories
 target_include_directories(${BIN_NAME} PRIVATE

--- a/tests/unit/core/ut_basic_interfaces.cpp
+++ b/tests/unit/core/ut_basic_interfaces.cpp
@@ -22,7 +22,6 @@ protected:
     void SetUp() override
     {
         TestBase::SetUp();
-        qDebug() << "Setting up basic interfaces test";
     }
 };
 

--- a/tests/unit/core/ut_daierror.cpp
+++ b/tests/unit/core/ut_daierror.cpp
@@ -23,7 +23,6 @@ protected:
     void SetUp() override
     {
         TestBase::SetUp();
-        qDebug() << "Setting up DAIError interface tests";
     }
     
     void TearDown() override
@@ -63,8 +62,6 @@ protected:
  */
 TEST_F(TestDAIError, errorCodeDefinitions)
 {
-    qInfo() << "Testing DAIError code definitions";
-    
     // Test: Validate all defined error codes
     EXPECT_NO_THROW({
         AIErrorCode noError = NoError;

--- a/tests/unit/core/ut_data_types.cpp
+++ b/tests/unit/core/ut_data_types.cpp
@@ -30,7 +30,6 @@ protected:
     void SetUp() override
     {
         TestBase::SetUp();
-        qDebug() << "Setting up data types serialization tests";
     }
     
     void TearDown() override

--- a/tests/unit/nlp/ut_dchatcompletions.cpp
+++ b/tests/unit/nlp/ut_dchatcompletions.cpp
@@ -7,6 +7,7 @@
 
 #include "dtkai/dchatcompletions.h"
 #include "dtkai/dtkaitypes.h"
+#include "dtkai/DAIError"
 
 #include <QSignalSpy>
 #include <QTimer>
@@ -106,17 +107,16 @@ protected:
         // In test environment without AI daemon, error code 1 (APIServerNotAvailable) is expected
         // This is normal behavior and not a test failure
         if (expectedError) {
-            EXPECT_NE(error.getErrorCode(), -1) << "Expected an error to be set";
-            if (error.getErrorCode() != -1) {
+            EXPECT_NE(error.getErrorCode(), NoError) << "Expected an error to be set";
+            if (error.getErrorCode() != NoError) {
                 qDebug() << "Expected error code:" << error.getErrorCode() << "message:" << error.getErrorMessage();
             }
         } else {
             // In test environment, we may get APIServerNotAvailable (code 1) which is acceptable
-            if (error.getErrorCode() == 1) {
+            if (error.getErrorCode() == APIServerNotAvailable) {
                 qDebug() << "Info: AI daemon not available (error code 1) - this is normal in test environment";
-            } else if (error.getErrorCode() != -1) {
+            } else if (error.getErrorCode() != NoError) {
                 qDebug() << "Warning: Unexpected error code:" << error.getErrorCode() << "message:" << error.getErrorMessage();
-                // Don't fail the test for daemon unavailability
             }
         }
     }
@@ -406,7 +406,7 @@ TEST_F(TestDChatCompletions, errorHandling)
         
         // Check if error was set for empty prompt
         auto error = chat->lastError();
-        if (error.getErrorCode() != -1) {
+        if (error.getErrorCode() != NoError) {
             qDebug() << "Error for empty prompt:" << error.getErrorMessage();
         }
         
@@ -421,7 +421,7 @@ TEST_F(TestDChatCompletions, errorHandling)
         
         // Check if there was an error due to prompt length
         auto error = chat->lastError();
-        if (error.getErrorCode() != -1) {
+        if (error.getErrorCode() != NoError) {
             qDebug() << "Error for long prompt:" << error.getErrorMessage();
         }
         
@@ -438,7 +438,7 @@ TEST_F(TestDChatCompletions, errorHandling)
         
         // Check if invalid parameters caused an error
         auto error = chat->lastError();
-        if (error.getErrorCode() != -1) {
+        if (error.getErrorCode() != NoError) {
             qDebug() << "Error for invalid parameters:" << error.getErrorMessage();
         }
         

--- a/tests/unit/speech/ut_dspeechtotext.cpp
+++ b/tests/unit/speech/ut_dspeechtotext.cpp
@@ -7,6 +7,7 @@
 
 #include "dtkai/dspeechtotext.h"
 #include "dtkai/dtkaitypes.h"
+#include "dtkai/DAIError"
 
 #include <QSignalSpy>
 #include <QTimer>
@@ -140,15 +141,15 @@ protected:
         
         // In test environment without AI daemon, error code 1 (APIServerNotAvailable) is expected
         if (expectedError) {
-            EXPECT_NE(error.getErrorCode(), -1) << "Expected an error to be set";
-            if (error.getErrorCode() != -1) {
+            EXPECT_NE(error.getErrorCode(), NoError) << "Expected an error to be set";
+            if (error.getErrorCode() != NoError) {
                 qDebug() << "Expected error code:" << error.getErrorCode() << "message:" << error.getErrorMessage();
             }
         } else {
             // In test environment, we may get APIServerNotAvailable (code 1) which is acceptable
-            if (error.getErrorCode() == 1) {
+            if (error.getErrorCode() == APIServerNotAvailable) {
                 qDebug() << "Info: AI daemon not available (error code 1) - this is normal in test environment";
-            } else if (error.getErrorCode() != -1) {
+            } else if (error.getErrorCode() != NoError) {
                 qDebug() << "Warning: Unexpected error code:" << error.getErrorCode() << "message:" << error.getErrorMessage();
             }
         }
@@ -247,7 +248,7 @@ TEST_F(TestDSpeechToText, fileRecognition)
         
         // Check if error was set for non-existent file
         auto error = stt->lastError();
-        if (error.getErrorCode() != -1 && error.getErrorCode() != 1) {
+        if (error.getErrorCode() != NoError && error.getErrorCode() != 1) {
             qDebug() << "Error for non-existent file:" << error.getErrorCode() << error.getErrorMessage();
         }
         
@@ -421,24 +422,6 @@ TEST_F(TestDSpeechToText, informationMethods)
         
     }) << "getSupportedFormats should work correctly";
     
-    // Test: Get provider information (commented out - method not yet implemented)
-    /*
-    EXPECT_NO_THROW({
-        QString providerInfo = stt->getProviderInfo();
-        
-        qDebug() << "Provider info:" << providerInfo;
-        
-        // Provider info may be empty in test environment
-        if (!providerInfo.isEmpty()) {
-            EXPECT_LT(providerInfo.length(), 1000) << "Provider info should be reasonable length";
-        } else {
-            qDebug() << "No provider info returned - may be normal in test environment";
-        }
-    });
-    */
-    
-    qDebug() << "getProviderInfo test skipped - method not yet implemented";
-    
     qInfo() << "Information methods tests completed";
 }
 
@@ -485,7 +468,7 @@ TEST_F(TestDSpeechToText, errorHandling)
             
             // Should handle invalid format gracefully
             auto error = stt->lastError();
-            if (error.getErrorCode() != -1 && error.getErrorCode() != 1) {
+            if (error.getErrorCode() != NoError && error.getErrorCode() != 1) {
                 qDebug() << "Error for invalid audio:" << error.getErrorCode() << error.getErrorMessage();
             }
         }
@@ -606,7 +589,7 @@ TEST_F(TestDSpeechToText, parameterValidation)
         
         // Check if invalid parameters caused an error
         auto error = stt->lastError();
-        if (error.getErrorCode() != -1 && error.getErrorCode() != 1) {
+        if (error.getErrorCode() != NoError && error.getErrorCode() != 1) {
             qDebug() << "Error for invalid params:" << error.getErrorCode() << error.getErrorMessage();
         }
         

--- a/tests/unit/test_resources.qrc
+++ b/tests/unit/test_resources.qrc
@@ -1,0 +1,6 @@
+<!DOCTYPE RCC>
+<RCC version="1.0">
+    <qresource prefix="/test">
+        <file alias="textrecognition.png">../../assets/images/tests/textrecognition.png</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
- Removed the `synthesizeText` method from the `DTextToSpeech` class and its corresponding XML interface.
- Cleaned up the `TextToSpeechTest` class by removing tests related to text synthesis.
- Updated error handling in various components to use `NoError` for better clarity and consistency.
- Adjusted image recognition tests to utilize embedded resources for improved reliability.

Log: