### PR TITLE
feat: add model provider management methods and update tests

### DIFF
--- a/3rdparty/aidaemon/org.deepin.ai.daemon.modelinfo.xml
+++ b/3rdparty/aidaemon/org.deepin.ai.daemon.modelinfo.xml
@@ -22,5 +22,22 @@
       <arg name="modelName" type="s" direction="in"/>
       <arg type="s" direction="out"/>
     </method>
+    
+    <!-- Get the currently selected model for a specific capability -->
+    <method name="GetCurrentModelForCapability">
+      <arg name="capability" type="s" direction="in"/>
+      <arg type="s" direction="out"/>
+    </method>
+    
+    <!-- Get list of all available model providers -->
+    <method name="GetProviderList">
+      <arg type="as" direction="out"/>
+    </method>
+    
+    <!-- Get list of models for a specific provider -->
+    <method name="GetModelsForProvider">
+      <arg name="provider" type="s" direction="in"/>
+      <arg type="s" direction="out"/>
+    </method>
   </interface>
-</node> 
+</node>

--- a/examples/other/model_info_test.cpp
+++ b/examples/other/model_info_test.cpp
@@ -65,6 +65,29 @@ int main(int argc, char *argv[])
             qDebug() << "Model not found";
         }
     }
+
+    // Test 6: Test getProviderList
+     qDebug() << "\n6. Testing getProviderList";
+     QStringList providers = DModelManager::getProviderList();
+     qDebug() << "Providers:" << providers;
+
+     // Test 7: getModelsForProvider for each provider
+     qDebug() << "\n7. Testing getModelsForProvider";
+     for (const QString &provider : providers) {
+         qDebug() << "Provider:" << provider;
+         QList<ModelInfo> models = DModelManager::getModelsForProvider(provider);
+         qDebug() << "  Models count:" << models.size();
+         for (const ModelInfo &model : models) {
+             qDebug() << "    Model:" << model.modelName << "Capability:" << model.capability;
+         }
+     }
+
+     // Test 8: get selected model.
+     qDebug() << "\n8. get selected model. ---";
+     for (const QString &capability : capabilities) {
+         QString currentModel = DModelManager::currentModelForCapability(capability);
+         qDebug() << "AI capability:" << capability << " selected model:" << currentModel;
+     }
     
     qDebug() << "\n=== Test Complete ===";
     

--- a/include/dtkai/dmodelmanager.h
+++ b/include/dtkai/dmodelmanager.h
@@ -42,6 +42,14 @@ public:
     static QList<ModelInfo> availableModels(const QString &capability);
     static QList<ModelInfo> availableModels(); // All models
     static ModelInfo modelInfo(const QString &modelName);
+    
+    // Get the currently selected model for a specific capability
+    static QString currentModelForCapability(const QString &capability);
+
+    // Get list of all available model providers
+    static QStringList getProviderList();
+    // Get list of models for a specific provider
+    static QList<ModelInfo> getModelsForProvider(const QString &provider);
 
 private:
     // Private constructor - static class only

--- a/src/dmodelmanager.cpp
+++ b/src/dmodelmanager.cpp
@@ -201,3 +201,59 @@ ModelInfo DModelManager::modelInfo(const QString &modelName)
 
     return info;
 }
+
+QString DModelManager::currentModelForCapability(const QString &capability)
+{
+    auto interface = getModelInfoInterface();
+    if (!interface || !interface->isValid()) {
+        qCWarning(dtkaiModelManager) << "ModelInfo D-Bus interface not available";
+        return QString();
+    }
+
+    QDBusReply<QString> reply = interface->GetCurrentModelForCapability(capability);
+    if (!reply.isValid()) {
+        qCWarning(dtkaiModelManager) << "Failed to get current model for capability" << capability
+                                    << ":" << reply.error().message();
+        return QString();
+    }
+
+    return reply.value();
+}
+
+QStringList DModelManager::getProviderList()
+{
+    auto interface = getModelInfoInterface();
+    if (!interface || !interface->isValid()) {
+        qCWarning(dtkaiModelManager) << "ModelInfo D-Bus interface not available";
+        return QStringList();
+    }
+
+    QDBusReply<QStringList> reply = interface->GetProviderList();
+    if (!reply.isValid()) {
+        qCWarning(dtkaiModelManager) << "Failed to get provider list:" 
+                                    << reply.error().message();
+        return QStringList();
+    }
+
+    return reply.value();
+}
+
+QList<ModelInfo> DModelManager::getModelsForProvider(const QString &provider)
+{
+    auto interface = getModelInfoInterface();
+    if (!interface || !interface->isValid()) {
+        qCWarning(dtkaiModelManager) << "ModelInfo D-Bus interface not available";
+        return QList<ModelInfo>();
+    }
+
+    QDBusReply<QString> reply = interface->GetModelsForProvider(provider);
+    if (!reply.isValid()) {
+        qCWarning(dtkaiModelManager) << "Failed to get models for provider" << provider
+                                    << ":" << reply.error().message();
+        return QList<ModelInfo>();
+    }
+
+    QList<ModelInfo> models = parseModelsFromJson(reply.value());
+    qCDebug(dtkaiModelManager) << "Found" << models.size() << "models for provider" << provider;
+    return models;
+}


### PR DESCRIPTION
- Introduced management methods in the D-Bus interface for managing AI model providers.
- Implemented corresponding methods in `DModelManager` to retrieve available providers and their models.
- Updated `model_info_test` to include tests for the new provider management functionalities.

Log: